### PR TITLE
✨(s6) allow to shutdown jibri and stop the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
  - Initial version of the `jibri-pulseaudio` docker image based on
    `jitsi/jibri:stable-5765-1`
+ - Add possibility to shutdown jibri (eventually gracefully) and stop the
+   container
 
 [Unreleased]: https://github.com/openfun/jibri-pulseaudio/compare/86a5427cd81d7f21d8f7fe74f64a4e2167e9a140...main

--- a/docker/files/etc/services.d/30-jibri/finish
+++ b/docker/files/etc/services.d/30-jibri/finish
@@ -1,0 +1,14 @@
+#!/usr/bin/with-contenv bash
+
+# When jibri is shutdown (or gracefully shutdown), it exits with code 255.
+# In this case, we don't want S6 to restart the service. We want to stop all
+# services and shutdown the container.
+
+echo -n "Jibri exited with code $1. Action: " 1>&2
+
+if [[ $1 -eq 255 ]]; then
+  echo "shutting down all services." 1>&2
+  s6-svscanctl -t /var/run/s6/services
+else
+  echo "restarting." 1>&2
+fi


### PR DESCRIPTION
## Purpose

**Our use case :**
We want to setup a dynamic pool of jibri instances on Kubernetes, using the `jibri-pulseaudio` docker image.
We want to use Kubernetes' [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to manage the pool size, based on its usage.
During the scale down phase, Kubernetes might want to terminate a jibri container with an active recording session.
So, we need a way to gracefully shut-down a jibri container, in order to let the current recording session end before terminating the container.


With its internal API, jibri provides a way to shutdown (gracefully or not) its service. But since jibri is managed by S6 supervisor in this docker image, the jibri service is always restarted. This is the default behavior of a S6 service.

We want to shut down the entire container when jibri has been shutdown or gracefully shutdown.

## Proposal

S6 allows to write custom `finish` scripts for each service. They are called when the service process is stopped.
This commit introduces a custom handler that stops all services when jibri has been shutdown.

It allows to have the following scenario : 

1. The jibri container is running with all its S6 services up (xorg, icewm, pulseaudio and jibri). A recording session is active.
2. Kubernetes ask the container to gracefully shut-down with a [preStop hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks), by calling Jibri's internal API ([like this](https://github.com/jitsi/jibri/blob/master/resources/debian-package/opt/jitsi/jibri/graceful_shutdown.sh))
3. Jibri's process waits for the current recording session to complete and then exits with code 255
4. The custom finish handler introduced by this PR is executed by the S6 process manager.
5. The custom handler detects that Jibri has been voluntarily shut down with its exit code and ask S6 main process (s6-svscan) to stop all its services.
6. `s6-svscan` terminates all running services and exits
7. The container is now terminated.


**References :** 
 - [S6 - Writing an optional finish script](https://github.com/just-containers/s6-overlay#writing-an-optional-finish-script)
 - [Jibri - shutdown exit codes](https://github.com/jitsi/jibri/blob/26eeb53bd26710df78e722e339228f857b8bcc20/src/main/kotlin/org/jitsi/jibri/Main.kt#L110-L123)