### PR TITLE
📌(dependencies) pin base jibri image to jitsi/jibri:stable-6173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
  - Initial version of the `jibri-pulseaudio` docker image based on
-   `jitsi/jibri:stable-5765-1`
+   `jitsi/jibri:stable-6173`
  - Add possibility to shutdown jibri (eventually gracefully) and stop the
    container
  - Add JIBRI_NO_MEDIA_TIMEOUT, JIBRI_ALL_MUTED_TIMEOUT and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,7 @@ services:
       context: .
       args:
         BASE_IMAGE: jitsi/jibri
-        BASE_TAG: stable-5765-1
+        BASE_TAG: stable-6173
     image: "jibri-pulseaudio:${IMAGE_TAG:-dev}"
     cap_add:
       - SYS_ADMIN


### PR DESCRIPTION
## Purpose

We want to build this docker image based on the latest stable version of the `jitsi/jibri` image.

The image we used was embedding and old version of google-chrome which is not compatible with the latest version of jitsi.